### PR TITLE
Fix spelling errors involving "recurrance" and "occurrance"

### DIFF
--- a/po/eqonomize.pot
+++ b/po/eqonomize.pot
@@ -5602,7 +5602,7 @@ msgstr ""
 
 #: ../src/recurrenceeditwidget.cpp:320
 msgctxt "RecurrenceEditWidget|"
-msgid "Enable recurrance"
+msgid "Enable recurrence"
 msgstr ""
 
 #: ../src/recurrenceeditwidget.cpp:323
@@ -6826,7 +6826,7 @@ msgstr ""
 
 #: ../src/transactionlistwidget.cpp:1552
 msgctxt "TransactionListWidget|"
-msgid "** Recurring (editing occurrance)"
+msgid "** Recurring (editing occurrence)"
 msgstr ""
 
 #: ../src/transactionlistwidget.cpp:1568

--- a/src/recurrenceeditwidget.cpp
+++ b/src/recurrenceeditwidget.cpp
@@ -317,7 +317,7 @@ RecurrenceEditWidget::RecurrenceEditWidget(const QDate &startdate, Budget *budg,
 	QVBoxLayout *recurrenceLayout = new QVBoxLayout(this);
 	//recurrenceLayout->setContentsMargins(0, 0, 0, 0);
 
-	recurrenceButton = new QCheckBox(tr("Enable recurrance"), this);
+	recurrenceButton = new QCheckBox(tr("Enable recurrence"), this);
 	recurrenceLayout->addWidget(recurrenceButton);
 
 	ruleGroup = new QGroupBox(tr("Recurrence Rule"), this);

--- a/src/transactionlistwidget.cpp
+++ b/src/transactionlistwidget.cpp
@@ -1621,7 +1621,7 @@ void TransactionListWidget::currentTransactionChanged(QTreeWidgetItem *i) {
 	} else if(((TransactionListViewItem*) i)->scheduledTransaction()) {
 		editWidget->setTransaction(((TransactionListViewItem*) i)->transaction(), ((TransactionListViewItem*) i)->date());
 		if(((TransactionListViewItem*) i)->scheduledTransaction()->isOneTimeTransaction()) editInfoLabel->setText(QString::null);
-		else editInfoLabel->setText(tr("** Recurring (editing occurrance)"));
+		else editInfoLabel->setText(tr("** Recurring (editing occurrence)"));
 	} else {
 		editWidget->setTransaction(((TransactionListViewItem*) i)->transaction());
 		editInfoLabel->setText(QString::null);

--- a/translations/eqonomize_bg.ts
+++ b/translations/eqonomize_bg.ts
@@ -2057,7 +2057,7 @@ i18n: file ./eqonomizeui.rc line 56
         <translation type="vanished">Крайната дата е преди началната дата.</translation>
     </message>
     <message>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="vanished">Разрешаване на повторение</translation>
     </message>
     <message>
@@ -2454,7 +2454,7 @@ i18n: file ./eqonomizeui.rc line 56
         <translation type="vanished">* Част от разделянето (%1)</translation>
     </message>
     <message>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="vanished">** Повторение (редактирени на събитието)</translation>
     </message>
     <message>
@@ -9546,7 +9546,7 @@ Date: %3</source>
     <name>RecurrenceEditWidget</name>
     <message>
         <location filename="../src/recurrenceeditwidget.cpp" line="320"/>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation>Разрешаване на повторение</translation>
     </message>
     <message>
@@ -11061,7 +11061,7 @@ Date: %3</source>
     </message>
     <message>
         <location filename="../src/transactionlistwidget.cpp" line="1624"/>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation>** Повторение (редактирени на събитието)</translation>
     </message>
     <message>

--- a/translations/eqonomize_cs.ts
+++ b/translations/eqonomize_cs.ts
@@ -1925,7 +1925,7 @@ i18n: file ./eqonomizeui.rc line 56
         <translation type="vanished">Datum ukončení předchází datumu zahájení.</translation>
     </message>
     <message>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="vanished">Zapnout opakování</translation>
     </message>
     <message>
@@ -2317,7 +2317,7 @@ i18n: file ./eqonomizeui.rc line 56
         <translation type="vanished">Část rozdělení (%1)</translation>
     </message>
     <message>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="vanished">**Opakování (upravující výskyt)</translation>
     </message>
     <message>
@@ -9481,7 +9481,7 @@ Date: %3</source>
     <name>RecurrenceEditWidget</name>
     <message>
         <location filename="../src/recurrenceeditwidget.cpp" line="320"/>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation>Zapnout opakování</translation>
     </message>
     <message>
@@ -11014,7 +11014,7 @@ Date: %3</source>
     </message>
     <message>
         <location filename="../src/transactionlistwidget.cpp" line="1624"/>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation>**Opakování (upravující výskyt)</translation>
     </message>
     <message>

--- a/translations/eqonomize_de.ts
+++ b/translations/eqonomize_de.ts
@@ -2013,7 +2013,7 @@ Was wollen Sie mit diesen tun?</translation>
         <translation type="vanished">Endzeitpunkt vor Startzeitpunkt.</translation>
     </message>
     <message>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="vanished">Wiederholung aktivieren</translation>
     </message>
     <message>
@@ -2410,7 +2410,7 @@ Was wollen Sie mit diesen tun?</translation>
         <translation type="vanished">* Teil (%1)</translation>
     </message>
     <message>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="vanished">** Wiederkehrend (bearbeite Vorkommen)</translation>
     </message>
     <message>
@@ -9571,7 +9571,7 @@ Datum: %3</translation>
     <name>RecurrenceEditWidget</name>
     <message>
         <location filename="../src/recurrenceeditwidget.cpp" line="320"/>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation>Wiederholung aktivieren</translation>
     </message>
     <message>
@@ -11086,7 +11086,7 @@ Datum: %3</translation>
     </message>
     <message>
         <location filename="../src/transactionlistwidget.cpp" line="1624"/>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation>** Wiederkehrend (bearbeite Vorkommen)</translation>
     </message>
     <message>

--- a/translations/eqonomize_es.ts
+++ b/translations/eqonomize_es.ts
@@ -2470,7 +2470,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="vanished">Repetición permitida</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -9868,7 +9868,7 @@ Fecha: %3</translation>
     <name>RecurrenceEditWidget</name>
     <message>
         <location filename="../src/recurrenceeditwidget.cpp" line="320"/>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="unfinished">Repetición permitida</translation>
     </message>
     <message>
@@ -11340,7 +11340,7 @@ Fecha: %3</translation>
     </message>
     <message>
         <location filename="../src/transactionlistwidget.cpp" line="1624"/>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/eqonomize_fr.ts
+++ b/translations/eqonomize_fr.ts
@@ -2485,7 +2485,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="vanished">Autoriser les récurrences</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -2980,7 +2980,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="vanished">** Se reproduit (éditer l&apos; occurrence)</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -10091,7 +10091,7 @@ Date: %3</translation>
     <name>RecurrenceEditWidget</name>
     <message>
         <location filename="../src/recurrenceeditwidget.cpp" line="320"/>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation>Autoriser les récurrences</translation>
     </message>
     <message>
@@ -11623,7 +11623,7 @@ Date: %3</translation>
     </message>
     <message>
         <location filename="../src/transactionlistwidget.cpp" line="1624"/>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation>** Se reproduit (éditer l&apos; occurrence)</translation>
     </message>
     <message>

--- a/translations/eqonomize_hu.ts
+++ b/translations/eqonomize_hu.ts
@@ -2547,7 +2547,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="vanished">Ismétlés megengedése</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -3042,7 +3042,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="vanished">** Ismétlődés (események szerkesztése)</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -10097,7 +10097,7 @@ Date: %3</source>
     <name>RecurrenceEditWidget</name>
     <message>
         <location filename="../src/recurrenceeditwidget.cpp" line="320"/>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation>Ismétlés megengedése</translation>
     </message>
     <message>
@@ -11608,7 +11608,7 @@ Date: %3</source>
     </message>
     <message>
         <location filename="../src/transactionlistwidget.cpp" line="1624"/>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation>** Ismétlődés (események szerkesztése)</translation>
     </message>
     <message>

--- a/translations/eqonomize_it.ts
+++ b/translations/eqonomize_it.ts
@@ -2501,7 +2501,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="vanished">Abilita ricorrenza</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -9969,7 +9969,7 @@ Data: %3</translation>
     <name>RecurrenceEditWidget</name>
     <message>
         <location filename="../src/recurrenceeditwidget.cpp" line="320"/>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="unfinished">Abilita ricorrenza</translation>
     </message>
     <message>
@@ -11472,7 +11472,7 @@ Data: %3</translation>
     </message>
     <message>
         <location filename="../src/transactionlistwidget.cpp" line="1624"/>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/eqonomize_nl.ts
+++ b/translations/eqonomize_nl.ts
@@ -2556,7 +2556,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="vanished">Herhaal deze transactie</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -3051,7 +3051,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="vanished">** Herhalend (individuele gebeurtenis wordt bewerkt)</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -10104,7 +10104,7 @@ Datum: %3</translation>
     <name>RecurrenceEditWidget</name>
     <message>
         <location filename="../src/recurrenceeditwidget.cpp" line="320"/>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="unfinished">Herhaal deze transactie</translation>
     </message>
     <message>
@@ -11615,7 +11615,7 @@ Datum: %3</translation>
     </message>
     <message>
         <location filename="../src/transactionlistwidget.cpp" line="1624"/>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="unfinished">** Herhalend (individuele gebeurtenis wordt bewerkt)</translation>
     </message>
     <message>

--- a/translations/eqonomize_pt.ts
+++ b/translations/eqonomize_pt.ts
@@ -2556,7 +2556,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="vanished">Ativar recorrência</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -3051,7 +3051,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="vanished">** A recorrer (editar ocurrência)</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -10076,7 +10076,7 @@ Data: %3</translation>
     <name>RecurrenceEditWidget</name>
     <message>
         <location filename="../src/recurrenceeditwidget.cpp" line="320"/>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="unfinished">Ativar recorrência</translation>
     </message>
     <message>
@@ -11587,7 +11587,7 @@ Data: %3</translation>
     </message>
     <message>
         <location filename="../src/transactionlistwidget.cpp" line="1624"/>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="unfinished">** A recorrer (editar ocurrência)</translation>
     </message>
     <message>

--- a/translations/eqonomize_pt_BR.ts
+++ b/translations/eqonomize_pt_BR.ts
@@ -2555,7 +2555,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="vanished">Habilirae Recorrência</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -3050,7 +3050,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="vanished">**Recorrendo (editar ocorrência)</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -10054,7 +10054,7 @@ Date: %3</source>
     <name>RecurrenceEditWidget</name>
     <message>
         <location filename="../src/recurrenceeditwidget.cpp" line="320"/>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="unfinished">Habilirae recorrência</translation>
     </message>
     <message>
@@ -11565,7 +11565,7 @@ Date: %3</source>
     </message>
     <message>
         <location filename="../src/transactionlistwidget.cpp" line="1624"/>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="unfinished">** Recorrendo (editar ocorrência)</translation>
     </message>
     <message>

--- a/translations/eqonomize_ro.ts
+++ b/translations/eqonomize_ro.ts
@@ -2568,7 +2568,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="vanished">Activează recurență</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -3063,7 +3063,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="vanished">** Recurentă (editare frecvență)</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -10102,7 +10102,7 @@ Date: %3</source>
     <name>RecurrenceEditWidget</name>
     <message>
         <location filename="../src/recurrenceeditwidget.cpp" line="320"/>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="unfinished">Activează recurență</translation>
     </message>
     <message>
@@ -11613,7 +11613,7 @@ Date: %3</source>
     </message>
     <message>
         <location filename="../src/transactionlistwidget.cpp" line="1624"/>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="unfinished">** Recurentă (editare frecvență)</translation>
     </message>
     <message>

--- a/translations/eqonomize_ru.ts
+++ b/translations/eqonomize_ru.ts
@@ -2409,7 +2409,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="vanished">Разрешить повторение</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -2864,7 +2864,7 @@ i18n: file ./eqonomizeui.rc line 56
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
     <message>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="vanished">** Периодически (редактирование)</translation>
         <extra-po-flags>kde-format</extra-po-flags>
     </message>
@@ -9843,7 +9843,7 @@ Date: %3</source>
     <name>RecurrenceEditWidget</name>
     <message>
         <location filename="../src/recurrenceeditwidget.cpp" line="320"/>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="unfinished">Разрешить повторение</translation>
     </message>
     <message>
@@ -11311,7 +11311,7 @@ Date: %3</source>
     </message>
     <message>
         <location filename="../src/transactionlistwidget.cpp" line="1624"/>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="unfinished">** Периодически (редактирование)</translation>
     </message>
     <message>

--- a/translations/eqonomize_sk.ts
+++ b/translations/eqonomize_sk.ts
@@ -8005,7 +8005,7 @@ Date: %3</source>
     <name>RecurrenceEditWidget</name>
     <message>
         <location filename="../src/recurrenceeditwidget.cpp" line="320"/>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9437,7 +9437,7 @@ Date: %3</source>
     </message>
     <message>
         <location filename="../src/transactionlistwidget.cpp" line="1624"/>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/eqonomize_sv.ts
+++ b/translations/eqonomize_sv.ts
@@ -6193,7 +6193,7 @@ Datum: %3</translation>
     <name>RecurrenceEditWidget</name>
     <message>
         <location filename="../src/recurrenceeditwidget.cpp" line="320"/>
-        <source>Enable recurrance</source>
+        <source>Enable recurrence</source>
         <translation>Aktivera återkomst</translation>
     </message>
     <message>
@@ -7524,7 +7524,7 @@ Datum: %3</translation>
     </message>
     <message>
         <location filename="../src/transactionlistwidget.cpp" line="1624"/>
-        <source>** Recurring (editing occurrance)</source>
+        <source>** Recurring (editing occurrence)</source>
         <translation>** Återkommande (redigerar tillfälle)</translation>
     </message>
     <message>


### PR DESCRIPTION
Hi,

while working on the eqonomize Debian package, I stumbled upon several spelling errors involving the words "recurrance" (should be "recurrence") and "occurrance" (should be "occurrence").

This pull request fixes those spelling errors.

Best regards,
Fabian