### PR TITLE
Remove deprecated Encoding key from the .desktop file

### DIFF
--- a/data/eqonomize.desktop
+++ b/data/eqonomize.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=Eqonomize!
 GenericName=Personal Accounting
 GenericName[sv]=Bokföring


### PR DESCRIPTION
Hi,

I'm hereby forwarding a patch from the eqonomize Debian package (which is now up to date again, by the way) that was originally written by [Frank S. Thomas](https://qa.debian.org/developer.php?login=fst).

This patch removes the deprecated "Encoding" key from `data/eqonomize.desktop`; see [Appendix C](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#deprecated-items) of the relevant specification for details.

Best regards,
Fabian