### PR TITLE
Bump DocBook version

### DIFF
--- a/doc/C/index.docbook
+++ b/doc/C/index.docbook
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
-		"http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
+		"http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd" [
 	<!ENTITY legal SYSTEM "legal.xml">
 	<!ENTITY appversion "1.0.0">
 	<!ENTITY manrevision "1.0.0">


### PR DESCRIPTION
Hi,

this is another patch from the eqonomize Debian package, originally written by [Frank S. Thomas](https://qa.debian.org/developer.php?login=fst).

It updates the DocBook version used in `doc/C/index.docbook` from 4.1.2 to 4.2. This patch became necessary because of Debian bug [#628327](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=628327).

Best regards,
Fabian