### PR TITLE
CSV import: allow reuse of fields

### DIFF
--- a/src/importcsvdialog.cpp
+++ b/src/importcsvdialog.cpp
@@ -877,8 +877,9 @@ bool ImportCSVDialog::import(bool test, csv_info *ci) {
 		   || (payee_c > 0 && (payee_c == quantity_c || payee_c == tags_c))
 		   || (tags_c > 0 && (tags_c == quantity_c))
 	  ) {
-		QMessageBox::critical(this, tr("Error"), tr("The same column number is selected multiple times."));
-		return false;
+		if(QMessageBox::warning(this, tr("Warning"), tr("The same column number is selected multiple times. Proceed?"), QMessageBox::Ok | QMessageBox::Cancel) != QMessageBox::Ok) {
+			return false;
+		}
 	}
 	bool create_missing = createMissingButton->isChecked() && type != ALL_TYPES_ID;
 	QString description, comments, payee, tags;


### PR DESCRIPTION
It can actually in some cases be useful to import one field as multiple values, therefore convert the error into a warning.