### PR TITLE
Set locale to system locale when set to C locale

### DIFF
--- a/src/budget.cpp
+++ b/src/budget.cpp
@@ -213,7 +213,6 @@ Budget::Budget() {
 	b_record_new_securities = false;
 	i_tcrd = TRANSACTION_CONVERSION_RATE_AT_DATE;
 	null_incomes_account = new IncomesAccount(this, QString());
-	setlocale(LC_MONETARY, "");
 	struct lconv *lc = localeconv();
 	monetary_decimal_separator = QString::fromLocal8Bit(lc->mon_decimal_point);
 	if(monetary_decimal_separator.isEmpty()) monetary_decimal_separator = QLocale().decimalPoint();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,7 @@
 #include <QTextStream>
 #include <QIcon>
 #include <QLibraryInfo>
+#include <QLocale>
 
 #include <locale.h>
 
@@ -52,7 +53,12 @@ int main(int argc, char **argv) {
 	app.setOrganizationName("Eqonomize");
 	app.setApplicationVersion(VERSION);
 
-	setlocale(LC_MONETARY, "");
+	QString locale = setlocale(LC_MONETARY, NULL);
+	if(locale == QLocale::c().name()) {
+		setlocale(LC_MONETARY, QLocale::system().name().toLocal8Bit());
+	} else {
+		setlocale(LC_MONETARY, "");
+	}
 
 	QSettings settings;
 	settings.beginGroup("GeneralOptions");


### PR DESCRIPTION
I was running in to an issue with on mac where the current locale is "C" when launching the app. This will cause currency formatting to not work.

The fix I added was to check if the current locale is set to "C", then use the system locale reported through Qt. I also removed the `setlocale` in Budget, as we shouldn't need to set the locale again after doing it in main.