### PR TITLE
Correct German Translation for 'Yearly Rate'

### DIFF
--- a/translations/eqonomize_de.ts
+++ b/translations/eqonomize_de.ts
@@ -832,7 +832,7 @@ Bestätigen Sie, daß diese Transaktionen tatsächlich durchgeführt wurden (ode
     </message>
     <message>
         <source>Yearly Rate</source>
-        <translation type="vanished">Jährliche Gebühr</translation>
+        <translation type="vanished">Jährliche Rendite</translation>
     </message>
     <message>
         <source>Account</source>


### PR DESCRIPTION
This pull request updates the German translation of "Yearly Rate" from "Jährliche Gebühr" to "Jahresrendite." Based on the user manual, "Yearly Rate" refers to an annual return (including dividends) rather than a fee. The new term more accurately reflects this intended meaning for German-speaking users.